### PR TITLE
fix: make extended_ca spread to the whole 5120 bits

### DIFF
--- a/src/rule30.rs
+++ b/src/rule30.rs
@@ -46,7 +46,7 @@ impl Rule30 {
         }
     }
 
-    /// Rule 30: `next_state[i] = state[i-1] ^ state[i] | state[i+1]`
+    /// Rule 30: `next_state[i] = state[i-1] ^ (state[i] | state[i+1])`
     #[inline]
     fn step(&mut self) {
         for i in 0..SIZE {


### PR DESCRIPTION
Previously, only the bits with a distance of 64 could affect each other.

This PR adds a `rotate_left(2)` to make it spread to the whole 5120 bits in several iterations.